### PR TITLE
MNT: Update to smodels v3.0.1

### DIFF
--- a/recipe/add-missing-smodels-tools-printers-sdist-files.patch
+++ b/recipe/add-missing-smodels-tools-printers-sdist-files.patch
@@ -1,11 +1,11 @@
-From cc2f96d507c9c53834ea6298407963deb9342ecf Mon Sep 17 00:00:00 2001
+From b4b03a5d51b2a055ba05fed66b8b2c2f42bd3028 Mon Sep 17 00:00:00 2001
 From: Matthew Feickert <matthew.feickert@cern.ch>
-Date: Mon, 10 Mar 2025 23:52:30 +0100
+Date: Tue, 11 Mar 2025 00:16:55 +0100
 Subject: [PATCH] fix: Add missing smodels/tools/printers sdist files
 
 * As the add-printers-to-packaging.patch only went in to v3.0.3 the
   smodels/tools/printers directory was never being added to the
-  sdist when it was built and so the sdists are permenenlty broken.
+  sdist when it was built and so the sdists are permanently broken.
   To fix this requires adding in all the missing files in a patch.
 ---
  smodels/tools/printers/__init__.py       |   5 +

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: smodels
-  version: 3.0.0
+  version: 3.0.1
   # Python 3.8 enforced by numpy requirement
   python_min: 3.8
 
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/smodels-${{ version }}.tar.gz
-  sha256: 5871f280d2bf94722e01b73ca8e71dcd356eb22921c54a9b89a18eaaba2b9d7b
+  sha256: 52741657b7020f4fb95f4e6cea6254ef59cd29ddc9c0115a040365aff55d0961
   patches:
     - add-build-system.patch
     - add-python_requires.patch


### PR DESCRIPTION
* Update SModels to v3.0.1.
   - c.f. https://github.com/SModelS/smodels/releases/tag/3.0.1
* Add and apply missing smodels/tools/printers files fix patch.
   - As the add-printers-to-packaging.patch only went in to v3.0.3 the smodels/tools/printers directory was never being added to the sdist when it was built and so the sdists are permanently broken. To fix this requires adding in all the missing files in a patch to the v3.0.1 tag.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [N/A] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
