### PR TITLE
FIX: Add patch for packaging of check_fortran_compiler.sh

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "smodels-feedstock"
-version = "3.46.1"
+version = "3.47.0"
 description = "Pixi configuration for conda-forge/smodels-feedstock"
 authors = ["@conda-forge/smodels"]
 channels = ["conda-forge"]

--- a/recipe/package-check_fortran_compiler.patch
+++ b/recipe/package-check_fortran_compiler.patch
@@ -1,0 +1,58 @@
+From cd4db802bb7d64dd576b8c6d8b9089e6fa3e581d Mon Sep 17 00:00:00 2001
+From: Wolfgang Waltenberger <wolfgang.waltenberger@gmail.com>
+Date: Mon, 10 Mar 2025 13:05:00 +0100
+Subject: [PATCH] check_fortran_compiler.sh was not packaged
+
+---
+ setup.py | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 204bd685a..f8fbf8870 100755
+--- a/setup.py
++++ b/setup.py
+@@ -20,8 +20,8 @@ class OverrideInstall(install):
+ 
+     def run(self):
+         #uid, gid = 0, 0
+-        install.run(self) # calling install.run(self) insures that everything 
+-                # that happened previously still happens, 
++        install.run(self) # calling install.run(self) insures that everything
++                # that happened previously still happens,
+         install_as_user = True
+         try:
+             import getpass
+@@ -38,7 +38,7 @@ class OverrideInstall(install):
+                     self.do_egg_install()
+                 except Exception as e:
+                     pass
+-        # so the installation does not break! 
++        # so the installation does not break!
+         # here we start with doing our overriding and private magic ..
+         mode = 0o777
+         for filepath in self.get_outputs():
+@@ -88,8 +88,8 @@ def dataFiles ():
+     ret = []
+     ret.append ( ("smodels/", [ "smodels/version", "smodels/COPYING", "smodels/README.rst", "smodels/INSTALLATION.rst" ]) )
+     for directory in [ "smodels/share/", "smodels/share/models/",
+-          "smodels/etc/", "smodels/lib/nllfast/nllfast-1.2/", 
+-          "smodels/lib/nllfast/nllfast-2.1/", "smodels/lib/nllfast/nllfast-3.1/", 
++          "smodels/etc/", "smodels/lib/", "smodels/lib/nllfast/nllfast-1.2/",
++          "smodels/lib/nllfast/nllfast-2.1/", "smodels/lib/nllfast/nllfast-3.1/",
+           "smodels/lib/pythia6/", "smodels/lib/pythia8/", "smodels/lib/resummino/" ]:
+         ret.append ((directory, listDirectory (directory)))
+     for directory in ["inputFiles/slha/", "inputFiles/lhe/" ]:
+@@ -108,8 +108,8 @@ def compile():
+         return
+     needs_build = False
+     for i in sys.argv[1:]:
+-        if i in [ "build", "build_ext", "build_clib", "install", 
+-                  "install_lib", "bdist", "bdist_rpm", "bdist_dumb", 
++        if i in [ "build", "build_ext", "build_clib", "install",
++                  "install_lib", "bdist", "bdist_rpm", "bdist_dumb",
+                   "bdist_wininst", "bdist_wheel", "develop"]:
+             needs_build = True
+     if not needs_build:
+-- 
+2.48.1
+

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,9 +13,11 @@ package:
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/smodels-${{ version }}.tar.gz
   sha256: add7291375bcd31c55eb1a6b70ad2397f4ea0c44476e177842f0b469e78c3209
+  patches:
+    - package-check_fortran_compiler.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   python:


### PR DESCRIPTION
* Add patch to package missing smodels/lib/check_fortran_compiler.sh.
   - c.f. https://github.com/SModelS/smodels/commit/cd4db802bb7d64dd576b8c6d8b9089e6fa3e581d
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
