### PR TITLE
need to disallow scipy 1.16

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -33,7 +33,7 @@ requirements:
     - python >=${{ python_min }}
     - docutils >=0.3
     - numpy >=1.22.0
-    - scipy >=1.0.0
+    - scipy >=1.0.0, <1.16.0
     - sympy >=1.0.0
     - unum >=4.0.0
     - requests >=2.0.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
