### PR TITLE
MNT: Disallow scipy v1.16.0 to v1.16.2

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,3 @@
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -7,4 +5,4 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 python_min:
-- '3.9'
+- '3.10'

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,8 +31,6 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-curl -fsSL https://pixi.sh/install.sh | bash
-export PATH="~/.pixi/bin:$PATH"
 pushd "${FEEDSTOCK_ROOT}"
 arch=$(uname -m)
 if [[ "$arch" == "x86_64" ]]; then

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Current build status
 
 <table><tr><td>All platforms:</td>
     <td>
-      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24946&branchName=main">
+      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
         <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/smodels-feedstock?branchName=main">
       </a>
     </td>
@@ -102,12 +102,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -134,7 +134,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/smodels-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "smodels-feedstock"
-version = "3.51.1"  # conda-smithy version used to generate this file
+version = "3.52.3"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/smodels-feedstock"
 authors = ["@conda-forge/smodels"]
 channels = ["conda-forge"]
@@ -34,6 +34,7 @@ description = "List contents of smodels-feedstock packages built for variant lin
 
 [feature.smithy.dependencies]
 conda-smithy = "*"
+shellcheck = "*"
 [feature.smithy.tasks.build-locally]
 cmd = "python ./build-locally.py"
 description = "Build packages locally using the same setup scripts used in conda-forge's CI"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -4,7 +4,7 @@ context:
   name: smodels
   version: "3.1.0"
   # Python 3.8 enforced by numpy requirement
-  python_min: 3.8
+  python_min: "3.8"
 
 package:
   name: ${{ name|lower }}
@@ -15,7 +15,7 @@ source:
   sha256: e9981005e20302d49ef6fc4c833bb977cedaf07a4b276bb837b44ca3023873e2
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   python:
@@ -33,7 +33,7 @@ requirements:
     - python >=${{ python_min }}
     - docutils >=0.3
     - numpy >=1.22.0
-    - scipy >=1.0.0, <1.16.0
+    - scipy >=1.0.0,!=1.16.0,!=1.16.1,!=1.16.2
     - sympy >=1.0.0
     - unum >=4.0.0
     - requests >=2.0.0


### PR DESCRIPTION
* As an issue has been identified with the SciPy SLSQP Fortran to C rewrite that should be resolved in SciPy v1.16.3/v1.17.0, disallow SciPy v1.16.0, v1.16.1, and v1.16.2.
   - c.f. https://github.com/SModelS/smodels/pull/49
   - c.f. https://github.com/scikit-hep/pyhf/issues/2593
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
