### PR TITLE
MNT: Update NumPy run requirment to v2.0+

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,8 +3,8 @@ schema_version: 1
 context:
   name: smodels
   version: "3.1.1"
-  # Python 3.8 enforced by numpy requirement
-  python_min: "3.8"
+  # Python 3.9 enforced by numpy requirement
+  python_min: "3.9"
 
 package:
   name: ${{ name|lower }}
@@ -32,7 +32,7 @@ requirements:
   run:
     - python >=${{ python_min }}
     - docutils >=0.3
-    - numpy >=1.22.0
+    - numpy >=2.0.0
     - scipy >=1.0.0,!=1.16.0,!=1.16.1,!=1.16.2
     - sympy >=1.0.0
     - unum >=4.0.0


### PR DESCRIPTION
Amends PR #16 

* Update NumPy to v2.0.0+.
* Update python_min to 3.9 to meet NumPy requirement.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [N/A] Bumped the build number (if the version is unchanged)
   - Build failed in PR #16 so as there is no passing build don't need to bump
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
